### PR TITLE
GSM support

### DIFF
--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -173,6 +173,8 @@ def run_simulation(param_file, Nprocs=None, sjob_id=None):
     # ---------------------------
 
     skymodel = parse_skymodel(skyparam)
+    if not np.all(skymodel.freq_array == obs.freqs):      # Make sure frequencies match
+        raise ValueError("Skymodel frequencies do not match observation frequencies")
 
     # ---------------------------
     # Run simulation

--- a/healvis/skymodel.py
+++ b/healvis/skymodel.py
@@ -54,6 +54,10 @@ class skymodel(object):
                 return False
         return True
 
+    def set_data(self, data):
+        self.data = data
+        self._update()
+
     def _update(self):
         """
             Assume that whatever parameter was just changed has priority over others.

--- a/scripts/make_gsm_shell.py
+++ b/scripts/make_gsm_shell.py
@@ -2,8 +2,12 @@ import numpy as np
 import argparse
 import yaml
 import healpy as hp
+import os
 
-import pygsm
+try:
+    import pygsm
+except ImportError:
+    raise ImportError("pygsm package not found. This is required to use {}".format(os.path.basename(__file__)))
 import pyuvsim
 
 from healvis import skymodel

--- a/scripts/make_gsm_shell.py
+++ b/scripts/make_gsm_shell.py
@@ -1,0 +1,48 @@
+import numpy as np
+import argparse
+import yaml
+import healpy as hp
+
+import pygsm
+import pyuvsim
+
+from healvis import skymodel
+
+
+"""
+For a parameter file, generate a skymodel 
+"""
+
+parser = argparse.ArgumentParser()
+parser.add_argument(dest='param', help='obsparam yaml file')
+parser.add_argument('--nside', dest='nside', help='Final Nside to use', type=int, default=128)
+args = parser.parse_args()
+
+assert args.nside <= 512
+
+param_file = args.param
+
+with open(param_file, 'r') as yfile:
+    param_dict = yaml.safe_load(yfile)
+
+param_dict['config_path'] = '.'
+
+tele_dict, beam_list, beam_dict = pyuvsim.simsetup.parse_telescope_params(param_dict['telescope'], param_dict['config_path'])
+freq_dict = pyuvsim.simsetup.parse_frequency_params(param_dict['freq'])
+
+freq_array = freq_dict['freq_array'][0]
+
+sky = skymodel.skymodel(freq_array=freq_array)
+sky.Nside = args.nside
+
+maps = pygsm.GlobalSkyModel(freq_unit='Hz', basemap='haslam').generate(freq_array)
+
+sky.Npix = sky.Nside**2 * 12
+for fi, f in enumerate(freq_array):
+    maps[fi,:sky.Npix] = hp.ud_grade(maps[fi], args.nside)
+
+maps = maps[:,:sky.Npix]
+
+sky.set_data(maps.T)
+
+sky.write_hdf5('gsm_{:.2f}-{:.2f}MHz_nside{}.hdf5'.format(freq_array[0]/1e6,freq_array[-1]/1e6, args.nside))

--- a/scripts/skymodel_vis_sim.py
+++ b/scripts/skymodel_vis_sim.py
@@ -13,14 +13,8 @@
 Visibility simulation
 """
 
-import numpy as np
 import argparse
 import os
-import sys
-import yaml
-import pyuvsim
-from healvis.utils import comoving_voxel_volume
-from itertools import izip
 
 import healvis
 


### PR DESCRIPTION
Adds a script that generates an HDF5 skymodel object from the GSM, based on the frequencies specified in an obsparam yaml file.

Requires `pygsm` to work, so it's not included in the core `healvis` directory, but is useful for getting a foreground model in.