### PR TITLE
More skymodel integration

### DIFF
--- a/healvis/__init__.py
+++ b/healvis/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from . import visibility
-from . import utils
-from . import version
-from . import skymodel
-from . import simulator
+from .visibility import *
+from .utils import *
+from .skymodel import *
+from .simulator import *
 
+from . import version
 __version__ = version.version

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -182,7 +182,7 @@ def run_simulation(param_file, Nprocs=None, sjob_id=None):
 
     print("Running simulation")
     sys.stdout.flush()
-    visibs, time_array, baseline_inds = obs.make_visibilities(skymodel.data, Nprocs=Nprocs)
+    visibs, time_array, baseline_inds = obs.make_visibilities(skymodel, Nprocs=Nprocs)
 
     # ---------------------------
     # Beam^2 integral

--- a/healvis/skymodel.py
+++ b/healvis/skymodel.py
@@ -29,6 +29,7 @@ class skymodel(object):
     ref_chan = None
     pspec_amp = None
     freq_array = None
+    pix_area_sr = None
     Z_array = None
     data = None
     _updated = []
@@ -74,6 +75,7 @@ class skymodel(object):
             if p == 'Nside':
                 if self.Npix is None:
                     self.Npix = 12 * self.Nside**2
+                self.pix_area_sr = 4*np.pi/(12. * self.Nside**2)
                 if 'indices' not in ud:
                     if self.indices is None:
                         self.indices = np.arange(self.Npix)

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -1,8 +1,11 @@
-from healvis import visibility
+from healvis import visibility, skymodel
 from astropy.cosmology import WMAP9
 import nose.tools as nt
 import numpy as np
 import healpy as hp
+
+## TODO
+# Test a skymodel that isn't a complete-sky shell (ie., use the sky.indices key)
 
 # HERA site
 latitude = -30.7215277777
@@ -83,7 +86,9 @@ def test_vis_calc():
     obs.set_fov(fov)
     obs.set_beam('uniform')
 
-    visibs, times, bls = obs.make_visibilities(shell)
+    sky = skymodel(Nside=nside, freq_array=freqs, data=shell)
+
+    visibs, times, bls = obs.make_visibilities(sky)
     print(visibs)
     nt.assert_true(np.real(visibs) == 1.0)  # Unit point source at zenith
 

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -126,7 +126,9 @@ def test_offzenith_vis():
     resol = np.sqrt(pix_area)
     obs.set_beam('uniform')
 
-    vis_calc, times, bls = obs.make_visibilities(shell)
+    sky = skymodel(Nside=Nside, freq_array=np.array(freqs), data=shell)
+
+    vis_calc, times, bls = obs.make_visibilities(sky)
 
     phi_new, theta_new = hp.pix2ang(Nside, ind, lonlat=True)
     src_az, src_za = np.radians(phi - phi_new), np.radians(theta - theta_new)

--- a/healvis/visibility.py
+++ b/healvis/visibility.py
@@ -299,27 +299,27 @@ class observatory:
 
     def make_visibilities(self, shell, Nprocs=1):
         """
-        Orthoslant project sections of the shell (fov=radius, looping over centers)
         Make beam cube and fringe cube, multiply and sum.
         shell (Npix, Nfreq) = healpix shell, as an mparray (multiprocessing shared array)
 
         Takes a shell in Kelvin
         Returns visibility in Jy
         """
-        if len(shell.shape) == 3:
-            Nskies, Npix, Nfreqs = shell.shape
-        else:
-            Npix, Nfreqs = shell.shape
+
+        Nskies = shell.Nskies
+        Npix = shell.Npix
+        Nfreqs = shell.Nfreqs
+        pix_area_sr = shell.pix_area_sr
 
         assert Nfreqs == self.Nfreqs
+
         self.time0 = time.time()
-        Nside = hp.npix2nside(Npix)
         Nbls = len(self.array)
         self.Nside = Nside
-        pix_area_sr = 4 * np.pi / float(Npix)
         self.freqs = np.array(self.freqs)
         conv_fact = jy2Tstr(np.array(self.freqs), bm=pix_area_sr)
         self.Ntimes = len(self.pointing_centers)
+
         pcenter_list = np.array_split(self.pointing_centers, Nprocs)
         time_inds = np.array_split(range(self.Ntimes), Nprocs)
         procs = []

--- a/healvis/visibility.py
+++ b/healvis/visibility.py
@@ -1,8 +1,7 @@
-
 """
     Generate visibilities for a HEALPix shell.
 """
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from astropy.constants import c
@@ -307,6 +306,7 @@ class observatory:
         """
 
         Nskies = shell.Nskies
+        Nside = shell.Nside
         Npix = shell.Npix
         Nfreqs = shell.Nfreqs
         pix_area_sr = shell.pix_area_sr
@@ -328,7 +328,7 @@ class observatory:
         Nfin = mp.Value('i', 0)
         prog = progsteps(maxval=self.Ntimes)
         for pi in range(Nprocs):
-            p = mp.Process(name=pi, target=self.vis_calc, args=(pcenter_list[pi], time_inds[pi], shell, vis_array, Nfin))
+            p = mp.Process(name=pi, target=self.vis_calc, args=(pcenter_list[pi], time_inds[pi], shell.data, vis_array, Nfin))
             p.start()
             procs.append(p)
         while (Nfin.value < self.Ntimes) and np.any([p.is_alive() for p in procs]):


### PR DESCRIPTION
- Put all member classes in the outermost healvis namespace
- Have make_visibility use the Nside/Npix/Nskies attributes of the skymodel object instead of recalculating.
- Add pixel area calculation to skymodel.