### PR TITLE
[do not merge] PowerBeam and AnalyticBeam overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ install:
   - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
 script:
   - nosetests healvis
-  - pycodestyle . --ignore=E501,W503
+  - pycodestyle healvis/* healvis/tests/* --ignore=E501,W503

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ install:
   - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
 script:
   - nosetests healvis
-  - pycodestyle healvis/* healvis/tests/* --ignore=E501,W503
+  - pycodestyle healvis/*.py healvis/tests/*.py --ignore=E501,W503

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
@@ -22,14 +24,11 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage pandas scikit-learn h5py six
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage h5py six pyyaml numba
   - source activate test-environment
-  - conda install -c conda-forge healpy aipy pycodestyle
+  - conda install -c conda-forge healpy pycodestyle mpi4py
   - pip install coveralls
-  - pip install git+https://github.com/HERA-Team/pyuvdata.git
-  - pip install git+https://github.com/HERA-Team/uvtools.git
-  - pip install pyyaml
-  - pip install multiprocess
-  - pip install multiprocessing
+  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
 script:
   - nosetests healvis
+  - pycodestyle . --ignore=E501,W503

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: python
+python:
+  # We don't actually use the Travis Python, but this keeps it organized.
+  - "2.7"
+install:
+  # ensure that we have the full tag information available for version.py
+  - git fetch --unshallow --tags
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda install -q conda
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  # create environment and install dependencies
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage pandas scikit-learn h5py six
+  - source activate test-environment
+  - conda install -c conda-forge healpy aipy pycodestyle
+  - pip install coveralls
+  - pip install git+https://github.com/HERA-Team/pyuvdata.git
+  - pip install git+https://github.com/HERA-Team/uvtools.git
+  - pip install pyyaml
+  - pip install multiprocess
+  - pip install multiprocessing
+script:
+  - nosetests healvis

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source activate test-environment
   - conda install -c conda-forge healpy pycodestyle mpi4py
   - pip install coveralls
-  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
+  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git@uvbeam_healpix_interp
   - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
 script:
   - nosetests healvis

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - conda install -c conda-forge healpy pycodestyle mpi4py
   - pip install coveralls
   - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
+  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
 script:
   - nosetests healvis
   - pycodestyle . --ignore=E501,W503

--- a/healvis/__init__.py
+++ b/healvis/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from .visibility import *
-from .utils import *
-from .skymodel import *
-from .simulator import *
+from . import visibility
+from . import utils
+from . import skymodel
+from . import simulator
 
 from . import version
 __version__ = version.version

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -186,7 +186,7 @@ def run_simulation(param_file, Nprocs=None, sjob_id=None):
     # Beam^2 integral
     # ---------------------------
     za, az = obs.calc_azza(skymodel.Nside, obs.pointing_centers[0])
-    beam_sq_int = np.sum(obs.beam.beam_val(az[:, np.newaxis], za[:, np.newaxis], freqs[np.newaxis, :])**2, axis=0)
+    beam_sq_int = np.sum(obs.beam.beam_val(az, za, freqs)**2, axis=1)
     om = 4 * np.pi / (12 * skymodel.Nside)
     beam_sq_int = beam_sq_int * om
 

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -139,7 +139,7 @@ def run_simulation(param_file, Nprocs=None, sjob_id=None):
     uv_obj.Nants_data = np.unique(bls).size
     for (a1, a2) in bls:
         i1, i2 = np.where(anums == a1), np.where(anums == a2)
-        array.append(visibility.baseline(enu[i1], enu[i2]))
+        array.append(visibility.Baseline(enu[i1], enu[i2]))
         bl_array.append(uvutils.antnums_to_baseline(a1, a2, Nants))
     Nbls = len(bl_array)
     uv_obj.Nbls = Nbls
@@ -147,7 +147,7 @@ def run_simulation(param_file, Nprocs=None, sjob_id=None):
 
     bl_array = np.array(bl_array)
     freqs = freq_dict['freq_array'][0]  # Hz
-    obs = visibility.observatory(np.degrees(lat), np.degrees(lon), array=array, freqs=freqs)
+    obs = visibility.Observatory(np.degrees(lat), np.degrees(lon), array=array, freqs=freqs)
     obs.set_fov(fov)
     print("Observatory built.")
     print("Nbls: ", Nbls)

--- a/healvis/skymodel.py
+++ b/healvis/skymodel.py
@@ -19,7 +19,7 @@ from .utils import mparray, comoving_voxel_volume, comoving_distance
 f21 = 1420e6
 
 
-class skymodel(object):
+class SkyModel(object):
 
     Npix = None
     Nside = None
@@ -45,7 +45,7 @@ class skymodel(object):
         if self._updated is None:
             self._updated = []
         self._updated.append(name)
-        super(skymodel, self).__setattr__(name, value)
+        super(SkyModel, self).__setattr__(name, value)
 
     def __eq__(self, other):
         for k in self.valid_params:

--- a/healvis/skymodel.py
+++ b/healvis/skymodel.py
@@ -75,7 +75,7 @@ class SkyModel(object):
             if p == 'Nside':
                 if self.Npix is None:
                     self.Npix = 12 * self.Nside**2
-                self.pix_area_sr = 4*np.pi/(12. * self.Nside**2)
+                self.pix_area_sr = 4 * np.pi / (12. * self.Nside**2)
                 if 'indices' not in ud:
                     if self.indices is None:
                         self.indices = np.arange(self.Npix)

--- a/healvis/tests/test_skymodel.py
+++ b/healvis/tests/test_skymodel.py
@@ -1,4 +1,4 @@
-from healvis import skymodel
+from healvis.skymodel import skymodel
 from astropy.cosmology import Planck15
 import nose.tools as nt
 import numpy as np

--- a/healvis/tests/test_skymodel.py
+++ b/healvis/tests/test_skymodel.py
@@ -1,4 +1,4 @@
-from healvis.skymodel import skymodel
+from healvis.skymodel import SkyModel
 from astropy.cosmology import Planck15
 import nose.tools as nt
 import numpy as np
@@ -36,7 +36,7 @@ def verify_update(sky_obj):
 def test_update():
     Nfreqs = 100
     freq_array = np.linspace(167.0, 177.0, Nfreqs)
-    sky = skymodel(Nside=64, freq_array=freq_array)
+    sky = SkyModel(Nside=64, freq_array=freq_array)
     verify_update(sky)
     sky.ref_chan = 50
     sky.make_flat_spectrum_shell(sigma=2.0)
@@ -46,7 +46,7 @@ def test_update():
 def test_flat_spectrum():
     Nfreqs = 100
     freq_array = np.linspace(167.0, 177.0, Nfreqs)
-    sky = skymodel(Nside=64, freq_array=freq_array, ref_chan=50)
+    sky = SkyModel(Nside=64, freq_array=freq_array, ref_chan=50)
     sky.make_flat_spectrum_shell(sigma=2.0)
 
 
@@ -54,11 +54,11 @@ def test_write_read():
     testfilename = 'test_out.hdf5'
     Nfreqs = 10
     freq_array = np.linspace(167.0, 177.0, Nfreqs)
-    sky = skymodel(Nside=64, freq_array=freq_array, ref_chan=5)
+    sky = SkyModel(Nside=64, freq_array=freq_array, ref_chan=5)
     sky.make_flat_spectrum_shell(sigma=2.0)
     sky.write_hdf5(testfilename)
-    sky2 = skymodel()
-    sky3 = skymodel()
+    sky2 = SkyModel()
+    sky3 = SkyModel()
     sky2.read_hdf5(testfilename, shared_mem=True)
     sky3.read_hdf5(testfilename)
     nt.assert_equal(sky, sky2)

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -159,11 +159,12 @@ def test_PowerBeam():
     nt.assert_true(P3.bandpass_array.shape[1] == P3.Nfreqs == Nfreqs)
 
     # get beam value
-    az = np.linspace(0, 2*np.pi, 20, endpoint=False)
-    za = np.linspace(0, 1, 20, endpoint=False)
+    Npix = 20
+    az = np.linspace(0, 2*np.pi, Npix, endpoint=False)
+    za = np.linspace(0, 1, Npix, endpoint=False)
     b = P.beam_val(az, az, freqs, pol='XX')
     # check shape and rough value check (i.e. interpolation is near zenith as expected)
-    nt.assert_equal(b.shape, (Nfreqs, 20))
+    nt.assert_equal(b.shape, (Npix, Nfreqs))
     nt.assert_true(np.isclose(b.max(), 1.0, atol=1e-3))
 
     # shift frequnecies by a delta and assert beams are EXACLTY the same (i.e. no freq interpolation)
@@ -176,33 +177,33 @@ def test_PowerBeam():
 def test_AnalyticBeam():
     freqs = np.arange(120e6, 160e6, 4e6)
     Nfreqs = len(freqs)
-    Nza = 20
-    az = np.linspace(0, 2*np.pi, Nza, endpoint=False)
-    za = np.linspace(0, 1, Nza, endpoint=False)
+    Npix = 20
+    az = np.linspace(0, 2*np.pi, Npix, endpoint=False)
+    za = np.linspace(0, 1, Npix, endpoint=False)
 
     # Gaussian
     A = visibility.AnalyticBeam('gaussian', sigma=15.0)
     b = A.beam_val(az, za, freqs)
-    nt.assert_equal(b.shape, (Nfreqs, Nza))  # assert array shape
-    nt.assert_true(np.isclose(b[:, 0], 1.0).all())  # assert peak normalized
+    nt.assert_equal(b.shape, (Npix, Nfreqs))  # assert array shape
+    nt.assert_true(np.isclose(b[0, :], 1.0).all())  # assert peak normalized
 
     # Uniform
     A = visibility.AnalyticBeam('uniform')
     b = A.beam_val(az, za, freqs)
-    nt.assert_equal(b.shape, (Nfreqs, Nza))  # assert array shape
+    nt.assert_equal(b.shape, (Npix, Nfreqs))  # assert array shape
     nt.assert_true(np.isclose(b, 1.0).all())
 
     # Airy
     A = visibility.AnalyticBeam('airy', diameter=15.0)
     b = A.beam_val(az, za, freqs)
-    nt.assert_equal(b.shape, (Nfreqs, Nza))  # assert array shape
-    nt.assert_true(np.isclose(b[:, 0], 1.0).all())  # assert peak normalized
+    nt.assert_equal(b.shape, (Npix, Nfreqs))  # assert array shape
+    nt.assert_true(np.isclose(b[0, :], 1.0).all())  # assert peak normalized
 
     # custom
     A = visibility.AnalyticBeam(visibility.airy_disk)
     b2 = A.beam_val(az, za, freqs, diameter=15.0)
-    nt.assert_equal(b2.shape, (Nfreqs, Nza))  # assert array shape
-    nt.assert_true(np.isclose(b2[:, 0], 1.0).all())  # assert peak normalized
+    nt.assert_equal(b2.shape, (Npix, Nfreqs))  # assert array shape
+    nt.assert_true(np.isclose(b2[0, :], 1.0).all())  # assert peak normalized
     np.testing.assert_array_almost_equal(b, b2)  # assert its the same as airy
 
     # exceptions
@@ -210,4 +211,3 @@ def test_AnalyticBeam():
     nt.assert_raises(NotImplementedError, visibility.AnalyticBeam, "foo")
     nt.assert_raises(KeyError, visibility.AnalyticBeam, "gaussian")
     nt.assert_raises(KeyError, visibility.AnalyticBeam, "airy")
-

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -3,6 +3,9 @@ from astropy.cosmology import WMAP9
 import nose.tools as nt
 import numpy as np
 import healpy as hp
+from healvis.data import DATA_PATH
+import os
+import copy
 
 # HERA site
 latitude = -30.7215277777
@@ -16,7 +19,7 @@ def test_pointings():
     dt_days = dt_min * 1 / 60. * 1 / 24.  # 20 minutes in days
 
     time_arr = np.arange(20) * dt_days + t0
-    obs = visibility.observatory(latitude, longitude)
+    obs = visibility.Observatory(latitude, longitude)
 
     obs.set_pointings(time_arr)
 
@@ -35,7 +38,7 @@ def test_az_za():
     Check the calculated azimuth and zenith angle of a point exactly 5 deg east on the sphere (az = 90d, za = 5d)
     """
     Nside = 128
-    obs = visibility.observatory(latitude, longitude)
+    obs = visibility.Observatory(latitude, longitude)
     center = [0, 0]
     lon, lat = [5, 0]
     ind0 = hp.ang2pix(Nside, lon, lat, lonlat=True)
@@ -58,7 +61,7 @@ def test_vis_calc():
     ant1_enu = np.array([0, 0, 0])
     ant2_enu = np.array([0.0, 14.6, 0])
 
-    bl = visibility.baseline(ant1_enu, ant2_enu)
+    bl = visibility.Baseline(ant1_enu, ant2_enu)
 
     freqs = np.array([1e8])
     nfreqs = 1
@@ -77,7 +80,7 @@ def test_vis_calc():
     shell[ind] = 1  # Jy/pix
     shell[ind] *= visibility.jy2Tstr(freqs[0], bm=pix_area)  # K
 
-    obs = visibility.observatory(latitude, longitude, array=[bl], freqs=freqs)
+    obs = visibility.Observatory(latitude, longitude, array=[bl], freqs=freqs)
     obs.pointing_centers = centers
     obs.times_jd = np.array([1])
     obs.set_fov(fov)
@@ -85,7 +88,7 @@ def test_vis_calc():
 
     visibs, times, bls = obs.make_visibilities(shell)
     print(visibs)
-    nt.assert_true(np.real(visibs) == 1.0)  # Unit point source at zenith
+    nt.assert_true(np.isclose(np.real(visibs), 1.0).all())  # Unit point source at zenith
 
 
 def test_offzenith_vis():
@@ -98,7 +101,7 @@ def test_offzenith_vis():
     ant1_enu = np.array([0, 0, 0])
     ant2_enu = np.array([0.0, 140.6, 0])
 
-    bl = visibility.baseline(ant1_enu, ant2_enu)
+    bl = visibility.Baseline(ant1_enu, ant2_enu)
 
     Nside = 128
     ind = 9081
@@ -114,7 +117,7 @@ def test_offzenith_vis():
     shell[ind] = 1  # Jy/pix
     shell[ind] *= visibility.jy2Tstr(freqs[0], pix_area)  # K
 
-    obs = visibility.observatory(latitude, longitude, array=[bl], freqs=freqs)
+    obs = visibility.Observatory(latitude, longitude, array=[bl], freqs=freqs)
     obs.pointing_centers = [[phi, theta]]
     obs.times_jd = np.array([1])
     obs.set_fov(fov)
@@ -135,26 +138,76 @@ def test_offzenith_vis():
     print(vis_analytic)
     print(vis_calc)
 
-    nt.assert_true(np.isclose(vis_analytic, vis_calc, atol=1e-3))
+    nt.assert_true(np.isclose(vis_calc, vis_analytic, atol=1e-3).all())
 
 
-@nt.nottest
-def test_hera_beam():
-    beam_path = '/users/alanman/data/alanman/NickFagnoniBeams/HERA_NicCST_fullfreq.uvbeam'
-    beam = visibility.powerbeam(beam_path)
+def test_PowerBeam():
+    # load it
+    beam_path = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
+    P = visibility.PowerBeam(beam_path)
+    freqs = np.arange(120e6, 160e6, 4e6)
+    Nfreqs = len(freqs)
 
-    Nside = 64
-    center = [0, 0]
-    obs = visibility.observatory(latitude, longitude)
-    obs.set_fov(40)
-    za, az, inds = obs.calc_azza(Nside, center, return_inds=True)
-    bv = beam.beam_val(az, za)
-    beam.to_healpix(Nside)
-    pix2 = hp.query_disc(Nside, [0, 0, 0], np.radians(20))
-    map1 = np.zeros(12 * Nside**2)
-    map1[pix2] = beam.data_array[0, 0, 0, 0][pix2]
+    # test frequency interpolation
+    P2 = copy.deepcopy(P)
+    P3 = P2.interp_freq(freqs, inplace=False, kind='linear')
+    P2.interp_freq(freqs, inplace=True, kind='linear')
+    # assert inplace and not inplace are consistent
+    nt.assert_equal(P2, P3)
+    # assert correct frequencies
+    np.testing.assert_array_almost_equal(freqs, P3.freq_array[0])
+    nt.assert_true(P3.bandpass_array.shape[1] == P3.Nfreqs == Nfreqs)
 
-    nt.assert_equal(np.around(np.sum(map1)), np.around(np.sum(map0)))   # Close to nearest integer
+    # get beam value
+    az = np.linspace(0, 2*np.pi, 20, endpoint=False)
+    za = np.linspace(0, 1, 20, endpoint=False)
+    b = P.beam_val(az, az, freqs, pol='XX')
+    # check shape and rough value check (i.e. interpolation is near zenith as expected)
+    nt.assert_equal(b.shape, (Nfreqs, 20))
+    nt.assert_true(np.isclose(b.max(), 1.0, atol=1e-3))
 
-    # Question --- Which beam component is the right one? (Can I construct pseudo-stokes I?)
-#    import IPython; IPython.embed()
+    # shift frequnecies by a delta and assert beams are EXACLTY the same (i.e. no freq interpolation)
+    # delta must be larger than UVBeam._inter_freq tol, but small enough
+    # to keep the same freq nearest neighbors
+    b2 = P.beam_val(az, az, freqs + 1e6, pol='XX')
+    np.testing.assert_array_almost_equal(b, b2)
+
+
+def test_AnalyticBeam():
+    freqs = np.arange(120e6, 160e6, 4e6)
+    Nfreqs = len(freqs)
+    Nza = 20
+    az = np.linspace(0, 2*np.pi, Nza, endpoint=False)
+    za = np.linspace(0, 1, Nza, endpoint=False)
+
+    # Gaussian
+    A = visibility.AnalyticBeam('gaussian', sigma=15.0)
+    b = A.beam_val(az, za, freqs)
+    nt.assert_equal(b.shape, (Nfreqs, Nza))  # assert array shape
+    nt.assert_true(np.isclose(b[:, 0], 1.0).all())  # assert peak normalized
+
+    # Uniform
+    A = visibility.AnalyticBeam('uniform')
+    b = A.beam_val(az, za, freqs)
+    nt.assert_equal(b.shape, (Nfreqs, Nza))  # assert array shape
+    nt.assert_true(np.isclose(b, 1.0).all())
+
+    # Airy
+    A = visibility.AnalyticBeam('airy', diameter=15.0)
+    b = A.beam_val(az, za, freqs)
+    nt.assert_equal(b.shape, (Nfreqs, Nza))  # assert array shape
+    nt.assert_true(np.isclose(b[:, 0], 1.0).all())  # assert peak normalized
+
+    # custom
+    A = visibility.AnalyticBeam(visibility.airy_disk)
+    b2 = A.beam_val(az, za, freqs, diameter=15.0)
+    nt.assert_equal(b2.shape, (Nfreqs, Nza))  # assert array shape
+    nt.assert_true(np.isclose(b2[:, 0], 1.0).all())  # assert peak normalized
+    np.testing.assert_array_almost_equal(b, b2)  # assert its the same as airy
+
+    # exceptions
+    A = visibility.AnalyticBeam("uniform")
+    nt.assert_raises(NotImplementedError, visibility.AnalyticBeam, "foo")
+    nt.assert_raises(KeyError, visibility.AnalyticBeam, "gaussian")
+    nt.assert_raises(KeyError, visibility.AnalyticBeam, "airy")
+

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -167,7 +167,7 @@ def test_PowerBeam():
 
     # get beam value
     Npix = 20
-    az = np.linspace(0, 2*np.pi, Npix, endpoint=False)
+    az = np.linspace(0, 2 * np.pi, Npix, endpoint=False)
     za = np.linspace(0, 1, Npix, endpoint=False)
     b = P.beam_val(az, az, freqs, pol='XX')
     # check shape and rough value check (i.e. interpolation is near zenith as expected)
@@ -185,7 +185,7 @@ def test_AnalyticBeam():
     freqs = np.arange(120e6, 160e6, 4e6)
     Nfreqs = len(freqs)
     Npix = 20
-    az = np.linspace(0, 2*np.pi, Npix, endpoint=False)
+    az = np.linspace(0, 2 * np.pi, Npix, endpoint=False)
     za = np.linspace(0, 1, Npix, endpoint=False)
 
     # Gaussian

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -89,7 +89,7 @@ def test_vis_calc():
     obs.set_fov(fov)
     obs.set_beam('uniform')
 
-    sky = skymodel(Nside=nside, freq_array=freqs, data=shell)
+    sky = skymodel.SkyModel(Nside=nside, freq_array=freqs, data=shell)
 
     visibs, times, bls = obs.make_visibilities(sky)
     print(visibs)
@@ -129,7 +129,7 @@ def test_offzenith_vis():
     resol = np.sqrt(pix_area)
     obs.set_beam('uniform')
 
-    sky = skymodel(Nside=Nside, freq_array=np.array(freqs), data=shell)
+    sky = skymodel.SkyModel(Nside=Nside, freq_array=np.array(freqs), data=shell)
 
     vis_calc, times, bls = obs.make_visibilities(sky)
 

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -7,7 +7,7 @@ from healvis.data import DATA_PATH
 import os
 import copy
 
-## TODO
+# TODO
 # Test a skymodel that isn't a complete-sky shell (ie., use the sky.indices key)
 
 # HERA site

--- a/healvis/visibility.py
+++ b/healvis/visibility.py
@@ -71,6 +71,7 @@ class PowerBeam(UVBeam):
     """
     Interface for using beamfits files.
     """
+
     def __init__(self, beamfits=None):
         """
         Initialize a PowerBeam object
@@ -152,7 +153,7 @@ class PowerBeam(UVBeam):
             za = np.array([za])
         az = np.asarray(az)
         za = np.asarray(za)
-        
+
         if self.pixel_coordinate_system == 'az_za':
             self.interpolation_function = 'az_za_simple'
         elif self.pixel_coordinate_system == 'healpix':
@@ -182,7 +183,7 @@ class PowerBeam(UVBeam):
             # healpix interpolation
             interp_beam, interp_basis = self._interp_healpix_bilinear(az_array=az, za_array=za, freq_array=freqs, polarizations=[pol])
 
-        return interp_beam[0, 0 ,0]
+        return interp_beam[0, 0, 0]
 
 
 class AnalyticBeam(object):
@@ -219,7 +220,7 @@ class AnalyticBeam(object):
             self.diameter = diameter
 
     def plot_beam(self, az, za, freqs, **kwargs):
-        ## TODO: needs development, and testing coverage?
+        # TODO: needs development, and testing coverage?
         fig = pl.figure()
         pl.imshow(self.beam_val(az, za, freqs, **kwargs))
         pl.show()
@@ -415,7 +416,8 @@ class Observatory:
         for count, c in enumerate(pcents):
             memory_usage_GB = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1e6
             za_arr, az_arr, pix = self.calc_azza(self.Nside, c, return_inds=True)
-            beam_cube = self.beam.beam_val(az_arr[:, np.newaxis], za_arr[:, np.newaxis], self.freqs[np.newaxis, :])
+            beam_cube = self.beam.beam_val(az_arr, za_arr, self.freqs)
+            beam_cube = np.moveaxis(beam_cube, -1, 0)
             for bi, bl in enumerate(self.array):
                 fringe_cube = bl.get_fringe(az_arr, za_arr, self.freqs)
                 vis = np.sum(shell[..., pix, :] * beam_cube * fringe_cube, axis=-2)

--- a/healvis/visibility.py
+++ b/healvis/visibility.py
@@ -21,14 +21,14 @@ from pyuvdata import UVBeam
 from .skymodel import SkyModel
 
 # Line profiling
-#from line_profiler import LineProfiler
-#import atexit
-#import __builtin__ as builtins
-#prof = LineProfiler()
-#builtins.__dict__['profile'] = prof
-#ofile = open('time_profiling.out', 'w')
+# from line_profiler import LineProfiler
+# import atexit
+# import __builtin__ as builtins
+# prof = LineProfiler()
+# builtins.__dict__['profile'] = prof
+# ofile = open('time_profiling.out', 'w')
 # atexit.register(ofile.close)
-#atexit.register(prof.print_stats, stream=ofile)
+# atexit.register(prof.print_stats, stream=ofile)
 
 c_ms = c.to('m/s').value
 

--- a/healvis/visibility.py
+++ b/healvis/visibility.py
@@ -463,6 +463,7 @@ class Observatory:
             p.start()
             procs.append(p)
         while (Nfin.value < self.Ntimes) and np.any([p.is_alive() for p in procs]):
+            continue
         visibilities = []
         time_inds, baseline_inds = [], []
 

--- a/healvis/visibility.py
+++ b/healvis/visibility.py
@@ -1,6 +1,5 @@
-
 """
-    Generate visibilities for a HEALPix shell.
+Generate visibilities from a HEALPix shell.
 """
 from __future__ import print_function
 
@@ -15,6 +14,7 @@ import sys
 import resource
 import time
 from scipy.special import j1
+import copy
 
 from pyuvdata import UVBeam
 from pyuvsim.utils import progsteps
@@ -46,79 +46,211 @@ def jy2Tstr(f, bm=1.0):
     return 1e-23 * lam**2 / (2 * k_boltz * bm)
 
 
-class powerbeam(UVBeam):
+def airy_disk(za_array, freqs, diameter=15.0):
     """
-    Interface for using beamfits files here.
+    Airy disk function for an antenna of specified diameter.
+
+    Args:
+        za_array: 1D ndarray, zenith angle [radians]
+        freqs: 1D array, observing frequencies [Hz]
+        diameter: float, antenna diameter [meters]
+
+    Returns:
+        beam: 2D array of shape (Nfreqs, Nza_array)
     """
+    Nfreqs, Nza_array = len(freqs), len(za_array)
+    xvals = diameter / 2. * np.sin(za_array.reshape(1, -1)) * 2. * np.pi * freqs.reshape(-1, 1) / c.value
+    zeros = np.isclose(xvals, 0.0)
+    beam = (2.0 * np.true_divide(j1(xvals), xvals, where=~zeros))**2.0
+    beam[zeros] = 1.0
 
-    # TODO Develop and test!
-    def __init__(self, beamfits_path=None):
-        super(powerbeam, self).__init__()
-        if beamfits_path is not None:
-            self.read_beamfits(beamfits_path)
+    return beam
 
-    def read_beamfits(self, beamfits_path):
-        super(powerbeam, self).read_beamfits(beamfits_path)
-        if not self.beam_type == 'power':
-            self.efield_to_power(calc_cross_pols=False)
-        self.interpolation_function = 'az_za_simple'
 
-    def beam_val(self, az, za, freq_Hz):
+class PowerBeam(UVBeam):
+    """
+    Interface for using beamfits files.
+    """
+    def __init__(self, beamfits=None):
         """
-        az, za = radians
+        Initialize a PowerBeam object
+
+        Args:
+            beamfits : str or UVBeam
+                A path to beamfits file or a UVBeam object
+            interp_mode : str
+                Interpolation method. See pyuvdata.UVBeam
         """
-        az = np.array(az)
-        za = np.array(za)
-        if isinstance(az, float):
+        # initialize
+        super(PowerBeam, self).__init__()
+
+        # read a beamfits
+        if beamfits is not None:
+            self.read_beamfits(beamfits)
+
+        # convert to power if efield
+        if self.beam_type == 'efield':
+            self.efield_to_power()
+
+    def interp_freq(self, freqs, inplace=False, kind='linear', run_check=True):
+        """
+        Interpolate object across frequency.
+
+        Args:
+            freqs: 1D frequency array [Hz]
+            inplace: bool, if True edit data in place, otherwise return a new UVBeam
+            kind: str, interpolation method. See scipy.interpolate.interp1d
+            run_check: bool, if True run attribute check on output object
+
+        Returns:
+            If not inplace, returns UVBeam object with interpolated frequencies
+        """
+        # make a new object
+        if inplace:
+            new_beam = self
+        else:
+            new_beam = copy.deepcopy(self)
+
+        interp_data, interp_bp = super(PowerBeam, self)._interp_freq(freqs, kind=kind)
+        new_beam.data_array = interp_data
+        new_beam.Nfreqs = interp_data.shape[3]
+        new_beam.freq_array = freqs.reshape(1, -1)
+        new_beam.bandpass_array = interp_bp
+        if hasattr(new_beam, 'saved_interp_functions'):
+            delattr(new_beam, 'saved_interp_functions')
+
+        if run_check:
+            new_beam.check()
+
+        if not inplace:
+            return new_beam
+
+    def beam_val(self, az, za, freqs, pol='pI', **kwargs):
+        """
+        Fast interpolation of power beam across the sky,
+        using UVBeam "simple" interpolation methods.
+
+        Note: this does not interpolate frequencies, instead
+        it just takes the nearest neighbor of each requested
+        frequency for speed. To interpolate the frequency axis
+        ahead of time, see self.interp_freq().
+
+        Args:
+            az : float or ndarray, azimuth angle [radian], must have len(za)
+            za : float or ndarray, zenith angle [radian], must have len(az)
+            freqs : float or ndarray, frequencies [Hz]
+            pol : str, requested visibility polarization, Ex: 'XX' or 'pI'.
+
+        Returns:
+            beam_value : ndarray of beam power, with shape (Nfreqs, Naz_array)
+        """
+        # type checks
+        assert self.beam_type == 'power', "beam_type must be power. See efield_to_power()"
+        if isinstance(az, (float, np.float, int, np.int)):
             az = np.array([az])
-        if isinstance(za, float):
+        if isinstance(za, (float, np.float, int, np.int)):
             za = np.array([za])
-        if freq_Hz is None:
-            freq_Hz = self.freq_array[0, 0]
-        if isinstance(freq_Hz, float):
-            freq_Hz = np.array([freq_Hz])
-        interp_beam, interp_basis = self.interp(az_array=az, za_array=za, freq_array=freq_Hz, reuse_spline=True)
-        return interp_beam[0, 0, 0, :]  # pol XX
+        az = np.asarray(az)
+        za = np.asarray(za)
+        
+        if self.pixel_coordinate_system == 'az_za':
+            self.interpolation_function = 'az_za_simple'
+        elif self.pixel_coordinate_system == 'healpix':
+            self.interpolation_function = 'healpix_simple'
+
+        if freqs is None:
+            freqs = self.freq_array[0]
+        else:
+            # get nearest neighbor of each reqeuested frequency
+            if isinstance(freqs, (float, np.float, int, np.int)):
+                freqs = np.array([freqs])
+            freqs = np.asarray(freqs)
+            assert freqs.ndim == 1, "input freqs array must be 1-dimensional"
+            freq_dists = np.abs(self.freq_array - freqs.reshape(-1, 1))
+            nearest_dist = np.min(freq_dists, axis=1)
+            nearest_inds = np.argmin(freq_dists, axis=1)
+            freqs = self.freq_array[0, nearest_inds]
+
+        assert isinstance(pol, str), "requested polarization must be a single string"
+
+        # interpolate
+        if self.pixel_coordinate_system == 'az_za':
+            # azimuth - zenith angle interpolation
+            interp_beam, interp_basis = self._interp_az_za_rect_spline(az_array=az, za_array=za, freq_array=freqs, reuse_spline=True, polarizations=[pol])
+
+        elif self.pixel_coordinate_system == 'healpix':
+            # healpix interpolation
+            interp_beam, interp_basis = self._interp_healpix_bilinear(az_array=az, za_array=za, freq_array=freqs, polarizations=[pol])
+
+        return interp_beam[0, 0 ,0]
 
 
-class analyticbeam(object):
+class AnalyticBeam(object):
 
     def __init__(self, beam_type, sigma=None, diameter=None):
-        if beam_type not in ['uniform', 'gaussian', 'airy']:
+        """
+        Instantiate an analytic beam model.
+
+        Currently this class only supports single-polarization beam models.
+
+        Args:
+            beam_type : str or callable, type of beam to use. options=['uniform', 'gaussian', 'airy', callable]
+            sigma : float, standard deviation [degrees] for gaussian beam
+            diameter : float, dish diameter [meter] used for airy beam
+
+        Notes:
+            Uniform beam is a flat-top beam across the entire sky.
+            Gaussian beam is a frequency independent, peak normalized Gaussian
+                with respect to zenith angle.
+            Airy beam uses the dish diameter to set the airy beam width as a function of frequency.
+            callable is any function that takes (za_array, freqs) in units [radians, Hz] respectively
+                and returns an ndarray of shape (Nfreqs, Nza_array) with power beam values.
+        """
+        if beam_type not in ['uniform', 'gaussian', 'airy'] and not callable(beam_type):
             raise NotImplementedError("Beam type " + str(beam_type) + " not available yet.")
         self.beam_type = beam_type
         if beam_type == 'gaussian':
             if sigma is None:
                 raise KeyError("Sigma required for gaussian beam")
             self.sigma = sigma * np.pi / 180.  # deg -> radians
-        if beam_type == 'airy':
+        elif beam_type == 'airy':
             if diameter is None:
                 raise KeyError("Dish diameter required for airy beam")
             self.diameter = diameter
 
-    def plot_beam(self, az, za):
+    def plot_beam(self, az, za, freqs, **kwargs):
+        ## TODO: needs development, and testing coverage?
         fig = pl.figure()
-        pl.imshow(self.beam_val(az, za))
+        pl.imshow(self.beam_val(az, za, freqs, **kwargs))
         pl.show()
 
-    def beam_val(self, az, za, freq_Hz):
+    def beam_val(self, az, za, freqs, **kwargs):
         """
-        az, za = radians
+        Evaluation of an analytic beam model.
 
+        Args:
+            az : float or ndarray, azimuth angle [radian], must have len(za)
+            za : float or ndarray, zenith angle [radian], must have len(az)
+            freqs : float or ndarray, frequencies [Hz]
+            kwargs : keyword arguments to pass if self.beam_type is callable
+
+        Returns:
+            beam_value : ndarray of beam power, with shape (Nfreqs, Naz_array)
         """
         if self.beam_type == 'uniform':
             if isinstance(az, np.ndarray):
-                return np.ones_like(az)
-            return 1
-        if self.beam_type == 'gaussian':
-            return np.exp(-(za**2) / (2 * self.sigma**2))  # Peak normalized
+                beam_value = np.ones((len(freqs), len(az)), dtype=np.float)
+            else:
+                beam_value = 1.0
+        elif self.beam_type == 'gaussian':
+            beam_value = np.exp(-(za**2) / (2 * self.sigma**2))  # Peak normalized
+            beam_value = np.repeat(beam_value[None], len(freqs), axis=0)
+        elif self.beam_type == 'airy':
+            beam_value = airy_disk(za, freqs, diameter=self.diameter)
+        elif callable(self.beam_type):
+            beam_value = self.beam_type(za, freqs, **kwargs)
 
-        if self.beam_type == 'airy':
-            xvals = self.diameter / 2. * np.sin(za) * 2. * np.pi * freq_Hz / 3e8
-            values = np.zeros_like(xvals)
-            values = (2. * j1(xvals) / xvals)**2
-            values[xvals == 0] = 1
-            return values
+        return beam_value
 
 
 @jit
@@ -138,7 +270,7 @@ def make_fringe(az, za, freq, enu):
     return fringe
 
 
-class baseline(object):
+class Baseline(object):
 
     def __init__(self, ant1_enu, ant2_enu):
         if not isinstance(ant1_enu, np.ndarray):
@@ -181,7 +313,7 @@ class baseline(object):
             pl.show()
 
 
-class observatory:
+class Observatory:
     """
     Baseline, time, frequency, location (lat/lon), beam
     Assumes the shell lat/lon are ra/dec.
@@ -209,12 +341,11 @@ class observatory:
             Dec = self.lat
         RA  = What RA is at zenith at a given JD?
         """
-
         telescope_location = EarthLocation.from_geodetic(self.lon, self.lat)
         self.times_jd = time_arr
         centers = []
         for t in Time(time_arr, scale='utc', format='jd'):
-            zen = AltAz(alt=Angle('89d'), az=Angle('0d'), obstime=t, location=telescope_location)
+            zen = AltAz(alt=Angle('90d'), az=Angle('0d'), obstime=t, location=telescope_location)
             zen_radec = zen.transform_to(ICRS)
             centers.append([zen_radec.ra.deg, zen_radec.dec.deg])
         self.pointing_centers = centers
@@ -253,7 +384,7 @@ class observatory:
         self.fov = fov
 
     def set_beam(self, beam_type='uniform', **kwargs):
-        self.beam = analyticbeam(beam_type, **kwargs)
+        self.beam = AnalyticBeam(beam_type, **kwargs)
 
     def get_observed_region(self, Nside):
         """

--- a/healvis/visibility.py
+++ b/healvis/visibility.py
@@ -17,7 +17,6 @@ from scipy.special import j1
 import copy
 
 from pyuvdata import UVBeam
-from pyuvsim.utils import progsteps
 
 from .skymodel import skymodel
 
@@ -459,14 +458,11 @@ class Observatory:
         man = mp.Manager()
         vis_array = man.Queue()
         Nfin = mp.Value('i', 0)
-        prog = progsteps(maxval=self.Ntimes)
         for pi in range(Nprocs):
             p = mp.Process(name=pi, target=self.vis_calc, args=(pcenter_list[pi], time_inds[pi], shell, vis_array, Nfin))
             p.start()
             procs.append(p)
         while (Nfin.value < self.Ntimes) and np.any([p.is_alive() for p in procs]):
-            prog.update(Nfin.value)
-        prog.finish()
         visibilities = []
         time_inds, baseline_inds = [], []
 

--- a/scripts/configs/obsparam_testfile.yaml
+++ b/scripts/configs/obsparam_testfile.yaml
@@ -14,7 +14,7 @@ sources:
 skymodel:
     sigma: 0.031      # 31 mK
     Nside: 64
-    filepath: 'flatspectrum.hdf5'
+    savepath: 'flatspectrum.hdf5'
     ref_chan: 10
 time:
   Ntimes: 5   # 24 hours

--- a/scripts/vis_param_sim.py
+++ b/scripts/vis_param_sim.py
@@ -204,7 +204,7 @@ for fi in range(Nfreqs):
 # Beam^2 integral
 # ---------------------------
 za, az = obs.calc_azza(Nside, obs.pointing_centers[0])
-beam_sq_int = np.sum(obs.beam.beam_val(az[:,np.newaxis], za[:,np.newaxis], freqs[np.newaxis,:])**2, axis=0)
+beam_sq_int = np.sum(obs.beam.beam_val(az, za, freqs)**2, axis=1)
 beam_sq_int = beam_sq_int * om
 
 # ---------------------------


### PR DESCRIPTION
Overhauls the `PowerBeam` class and standardizes it with `AnalyticBeam` such that they should be interchangeable with each other in a visibility simulator. This depends upon a PR on `pyuvdata` that updates the `UVBeam` interpolation methods for the capabilities added here. This also sets all class names to CamelCase PEP8 standard. Adds testing for the beam classes with example FITS beam model.

- `PowerBeam.get_beam_val` and `AnalyticBeam.get_beam_val` now *always* return a 2D ndarray of shape `(Npix, Nfreqs)`
- `PowerBeam.get_beam_val` never does frequency interpolation, and just takes the nearest neighbor of requested frequencies. This is because frequency interpolation should only be done once, and then slices of the freq-interpolated beams should be interpolated across the sky at different LSTs.
- `PowerBeam.interp_freq` allows one to interpolate the beam across frequency and returns a new `PowerBeam` object with the interpolated frequencies
- `AnalyticBeam.get_beam_val` conforms to new output standard, and also minor updates to code and adds a `callable` option for `beam_type`.