### PR TITLE
updated vis_calc and added history string output

### DIFF
--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -10,7 +10,7 @@ from pyuvdata import UVData
 from pyuvdata import utils as uvutils
 import pyuvsim
 
-from . import visibility
+from . import visibility, version
 from .skymodel import SkyModel
 
 
@@ -40,7 +40,7 @@ def parse_skyparam(param_dict):
     return sky
 
 
-def run_simulation(param_file, Nprocs=None, sjob_id=None):
+def run_simulation(param_file, Nprocs=None, sjob_id=None, add_to_history=''):
     """
     Parse input parameter file, construct UVData and SkyModel objects, and run simulation.
 
@@ -208,7 +208,7 @@ def run_simulation(param_file, Nprocs=None, sjob_id=None):
     uv_obj.set_uvws_from_antenna_positions()
     uv_obj.channel_width = np.diff(freqs)[0]
     uv_obj.integration_time = np.ones(uv_obj.Nblts) * np.diff(time_arr)[0] * 24 * 3600.  # Seconds
-    uv_obj.history = 'healvis'
+    uv_obj.history = version.history_string(add_to_history)
     uv_obj.set_drift()
     uv_obj.telescope_name = 'healvis'
     uv_obj.instrument = 'simulator'

--- a/healvis/skymodel.py
+++ b/healvis/skymodel.py
@@ -16,7 +16,7 @@ from .utils import mparray, comoving_voxel_volume, comoving_distance
 
 # Moving a lot from eorsky to here.
 
-f21 = 1420e6
+f21 = 1.420405751e9
 
 
 class SkyModel(object):

--- a/healvis/tests/test_visibility.py
+++ b/healvis/tests/test_visibility.py
@@ -14,7 +14,6 @@ import copy
 latitude = -30.7215277777
 longitude = 21.4283055554
 
-
 @nt.nottest
 def test_pointings():
     t0 = 2451545.0  # Start at J2000 epoch
@@ -34,119 +33,6 @@ def test_pointings():
     dts = np.diff(ras) / 15.04106 * 60.
     nt.assert_true(np.allclose(dts, dt_min, atol=1e-1))  # Within 6 seconds. Not great...
     nt.assert_true(np.allclose(decs, latitude, atol=1e-1))
-
-
-def test_az_za():
-    """
-    Check the calculated azimuth and zenith angle of a point exactly 5 deg east on the sphere (az = 90d, za = 5d)
-    """
-    Nside = 128
-    obs = visibility.Observatory(latitude, longitude)
-    center = [0, 0]
-    lon, lat = [5, 0]
-    ind0 = hp.ang2pix(Nside, lon, lat, lonlat=True)
-    lon, lat = hp.pix2ang(Nside, ind0, lonlat=True)
-    cvec = hp.ang2vec(center[0], center[1], lonlat=True)
-    radius = np.radians(10.)
-    obs.set_fov(20)
-    pix = hp.query_disc(Nside, cvec, radius)
-    za, az = obs.calc_azza(Nside, center)
-    ind = np.where(pix == ind0)
-    print(np.degrees(za[ind]), np.degrees(az[ind]))
-    print(lon, lat)
-    nt.assert_true(np.isclose(np.degrees(za[ind]), lon))
-    nt.assert_true(np.isclose(np.degrees(az[ind]), (lat - 90) % 360))
-
-
-def test_vis_calc():
-    # Construct a shell with a single point source at the zenith and confirm against analytic calculation.
-
-    ant1_enu = np.array([0, 0, 0])
-    ant2_enu = np.array([0.0, 14.6, 0])
-
-    bl = visibility.Baseline(ant1_enu, ant2_enu)
-
-    freqs = np.array([1e8])
-    nfreqs = 1
-
-    fov = 20  # Deg
-
-    # Longitude/Latitude in degrees.
-
-    nside = 128
-    ind = 10
-    center = list(hp.pix2ang(nside, ind, lonlat=True))
-    centers = [center]
-    npix = nside**2 * 12
-    shell = np.zeros((npix, nfreqs))
-    pix_area = 4 * np.pi / float(npix)
-    shell[ind] = 1  # Jy/pix
-    shell[ind] *= visibility.jy2Tstr(freqs[0], bm=pix_area)  # K
-
-    obs = visibility.Observatory(latitude, longitude, array=[bl], freqs=freqs)
-    obs.pointing_centers = centers
-    obs.times_jd = np.array([1])
-    obs.set_fov(fov)
-    obs.set_beam('uniform')
-
-    sky = skymodel.SkyModel(Nside=nside, freq_array=freqs, data=shell)
-
-    visibs, times, bls = obs.make_visibilities(sky)
-    print(visibs)
-    nt.assert_true(np.isclose(np.real(visibs), 1.0).all())  # Unit point source at zenith
-
-
-def test_offzenith_vis():
-    # Construct a shell with a single point source a known position off from zenith.
-    #   Similar to test_vis_calc, but set the pointing center 5deg off from the zenith and adjust analytic calculation
-
-    freqs = [1.0e8]
-    Nfreqs = 1
-    fov = 60
-    ant1_enu = np.array([0, 0, 0])
-    ant2_enu = np.array([0.0, 140.6, 0])
-
-    bl = visibility.Baseline(ant1_enu, ant2_enu)
-
-    Nside = 128
-    ind = 9081
-    center = list(hp.pix2ang(Nside, ind, lonlat=True))
-    centers = [center]
-    Npix = Nside**2 * 12
-    pix_area = 4 * np.pi / float(Npix)
-    shell = np.zeros((Npix, Nfreqs))
-
-    # Choose an index 5 degrees off from the pointing center
-    phi, theta = hp.pix2ang(Nside, ind, lonlat=True)
-    ind = hp.ang2pix(Nside, phi, theta - 5, lonlat=True)
-    shell[ind] = 1  # Jy/pix
-    shell[ind] *= visibility.jy2Tstr(freqs[0], pix_area)  # K
-
-    obs = visibility.Observatory(latitude, longitude, array=[bl], freqs=freqs)
-    obs.pointing_centers = [[phi, theta]]
-    obs.times_jd = np.array([1])
-    obs.set_fov(fov)
-    resol = np.sqrt(pix_area)
-    obs.set_beam('uniform')
-
-    sky = skymodel.SkyModel(Nside=Nside, freq_array=np.array(freqs), data=shell)
-
-    vis_calc, times, bls = obs.make_visibilities(sky)
-
-    phi_new, theta_new = hp.pix2ang(Nside, ind, lonlat=True)
-    src_az, src_za = np.radians(phi - phi_new), np.radians(theta - theta_new)
-    src_l = np.sin(src_az) * np.sin(src_za)
-    src_m = np.cos(src_az) * np.sin(src_za)
-    src_n = np.cos(src_za)
-    u, v, w = bl.get_uvw(freqs[0])
-
-    vis_analytic = (1) * np.exp(2j * np.pi * (u * src_l + v * src_m + w * src_n))
-
-    print(vis_analytic)
-    print(vis_calc)
-
-    nt.assert_true(np.isclose(vis_calc, vis_analytic, atol=1e-3).all())
-
 
 def test_PowerBeam():
     # load it
@@ -218,3 +104,166 @@ def test_AnalyticBeam():
     nt.assert_raises(NotImplementedError, visibility.AnalyticBeam, "foo")
     nt.assert_raises(KeyError, visibility.AnalyticBeam, "gaussian")
     nt.assert_raises(KeyError, visibility.AnalyticBeam, "airy")
+
+
+def test_Observatory():
+    # TODO: fill out test coverage
+
+    # setup
+    ant1 = np.array([15.0, 0, 0])
+    ant2 = np.array([0.0, 0, 0])
+    bl = visibility.Baseline(ant1, ant2)
+    Npix, Nfreqs = 10, 100
+    az = np.linspace(0, 2*np.pi, Npix)
+    za = np.linspace(0, np.pi, Npix)
+    freqs = np.linspace(100e6, 200e6, Nfreqs)
+    obs = visibility.Observatory(latitude, longitude, array=[bl], freqs=freqs)
+
+    # test Analytic set beam
+    for beam in ['uniform', 'gaussian', 'airy', visibility.airy_disk]:
+        obs.set_beam(beam, sigma=10, diameter=10)
+        nt.assert_true(isinstance(obs.beam, visibility.AnalyticBeam))
+        b = obs.beam.beam_val(az, za, freqs, pol='xx')
+        nt.assert_equal(b.shape, (Npix, Nfreqs))
+
+    # test Power set beam
+    obs.set_beam(os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits"))
+    nt.assert_true(isinstance(obs.beam, visibility.PowerBeam))
+    b = obs.beam.beam_val(az, za, freqs, pol='xx')
+    nt.assert_equal(b.shape, (Npix, Nfreqs))
+
+
+def test_Baseline():
+    # TODO: fill out test coverage
+
+    # setup
+    ant1 = np.array([15.0, 0, 0])
+    ant2 = np.array([0.0, 0, 0])
+    bl = visibility.Baseline(ant1, ant2)
+    Npix, Nfreqs = 10, 100
+    az = np.linspace(0, 2*np.pi, Npix)
+    za = np.linspace(0, np.pi, Npix)
+    freqs = np.linspace(100e6, 200e6, Nfreqs)
+
+    # test fringe is right dimensions
+    fringe = bl.get_fringe(az, za, freqs)
+    nt.assert_equal(fringe.shape, (Npix, Nfreqs))
+
+    # test fringe at zenith is 1.0 across all freqs
+    nt.assert_true(np.isclose(fringe[0, :], 1.0).all())
+
+
+####################
+# Validation Tests #
+####################
+
+def test_az_za():
+    """
+    Check the calculated azimuth and zenith angle of a point exactly 5 deg east on the sphere (az = 90d, za = 5d)
+    """
+    Nside = 128
+    obs = visibility.Observatory(latitude, longitude)
+    center = [0, 0]
+    lon, lat = [5, 0]
+    ind0 = hp.ang2pix(Nside, lon, lat, lonlat=True)
+    lon, lat = hp.pix2ang(Nside, ind0, lonlat=True)
+    cvec = hp.ang2vec(center[0], center[1], lonlat=True)
+    radius = np.radians(10.)
+    obs.set_fov(20)
+    pix = hp.query_disc(Nside, cvec, radius)
+    za, az = obs.calc_azza(Nside, center)
+    ind = np.where(pix == ind0)
+    print(np.degrees(za[ind]), np.degrees(az[ind]))
+    print(lon, lat)
+    nt.assert_true(np.isclose(np.degrees(za[ind]), lon))
+    nt.assert_true(np.isclose(np.degrees(az[ind]), (lat - 90) % 360))
+
+
+def test_vis_calc():
+    # Construct a shell with a single point source at the zenith and confirm against analytic calculation.
+    ant1_enu = np.array([0, 0, 0])
+    ant2_enu = np.array([0.0, 14.6, 0])
+
+    bl = visibility.Baseline(ant1_enu, ant2_enu)
+
+    freqs = np.array([1e8])
+    nfreqs = 1
+
+    fov = 20  # Deg
+
+    # Longitude/Latitude in degrees.
+
+    nside = 128
+    ind = 10
+    center = list(hp.pix2ang(nside, ind, lonlat=True))
+    centers = [center]
+    npix = nside**2 * 12
+    shell = np.zeros((npix, nfreqs))
+    pix_area = 4 * np.pi / float(npix)
+    shell[ind] = 1  # Jy/pix
+    shell[ind] *= visibility.jy2Tstr(freqs[0], bm=pix_area)  # K
+
+    obs = visibility.Observatory(latitude, longitude, array=[bl], freqs=freqs)
+    obs.pointing_centers = centers
+    obs.times_jd = np.array([1])
+    obs.set_fov(fov)
+    obs.set_beam('uniform')
+
+    sky = skymodel.SkyModel(Nside=nside, freq_array=freqs, data=shell)
+
+    visibs, times, bls = obs.make_visibilities(sky)
+    print(visibs)
+    nt.assert_true(np.isclose(np.real(visibs), 1.0).all())  # Unit point source at zenith
+
+def test_offzenith_vis():
+    # Construct a shell with a single point source a known position off from zenith.
+    #   Similar to test_vis_calc, but set the pointing center 5deg off from the zenith and adjust analytic calculation
+
+    freqs = [1.0e8]
+    Nfreqs = 1
+    fov = 60
+    ant1_enu = np.array([0, 0, 0])
+    ant2_enu = np.array([0.0, 140.6, 0])
+
+    bl = visibility.Baseline(ant1_enu, ant2_enu)
+
+    Nside = 128
+    ind = 9081
+    center = list(hp.pix2ang(Nside, ind, lonlat=True))
+    centers = [center]
+    Npix = Nside**2 * 12
+    pix_area = 4 * np.pi / float(Npix)
+    shell = np.zeros((Npix, Nfreqs))
+
+    # Choose an index 5 degrees off from the pointing center
+    phi, theta = hp.pix2ang(Nside, ind, lonlat=True)
+    ind = hp.ang2pix(Nside, phi, theta - 5, lonlat=True)
+    shell[ind] = 1  # Jy/pix
+    shell[ind] *= visibility.jy2Tstr(freqs[0], pix_area)  # K
+
+    obs = visibility.Observatory(latitude, longitude, array=[bl], freqs=freqs)
+    obs.pointing_centers = [[phi, theta]]
+    obs.times_jd = np.array([1])
+    obs.set_fov(fov)
+    resol = np.sqrt(pix_area)
+    obs.set_beam('uniform')
+
+    sky = skymodel.SkyModel(Nside=Nside, freq_array=np.array(freqs), data=shell)
+
+    vis_calc, times, bls = obs.make_visibilities(sky)
+
+    phi_new, theta_new = hp.pix2ang(Nside, ind, lonlat=True)
+    src_az, src_za = np.radians(phi - phi_new), np.radians(theta - theta_new)
+    src_l = np.sin(src_az) * np.sin(src_za)
+    src_m = np.cos(src_az) * np.sin(src_za)
+    src_n = np.cos(src_za)
+    u, v, w = bl.get_uvw(freqs[0])
+
+    vis_analytic = (1) * np.exp(2j * np.pi * (u * src_l + v * src_m + w * src_n))
+
+    print(vis_analytic)
+    print(vis_calc)
+
+    nt.assert_true(np.isclose(vis_calc, vis_analytic, atol=1e-3).all())
+
+

--- a/healvis/version.py
+++ b/healvis/version.py
@@ -9,6 +9,7 @@ import os
 import six
 import subprocess
 import json
+import inspect
 
 healvis_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -85,6 +86,21 @@ def construct_version_info():
             pass
 
     return version_info
+
+
+def history_string(notes=''):
+    '''Creates a standardized history string that all functions that write to disk can use. Optionally add notes.'''
+    history = '\n------------\nThis file was produced by the function ' + str(inspect.stack()[1][3]) + '()'
+    # inspect.stack()[1][3] is the name of the function that called this function
+    history += ' in ' + os.path.basename(inspect.stack()[1][1]) + ' using: '
+    # inspect.stack()[1][1] is path to the file that contains the function that called this function
+    version_info = construct_version_info()
+    for v in sorted(version_info.keys()):
+        history += '\n    ' + v + ': ' + version_info[v]
+    if (notes is not None) and (notes != ''):
+        history += '\n\nNotes:\n'
+        history += notes
+    return history + '\n------------\n'
 
 
 version_info = construct_version_info()


### PR DESCRIPTION
Recent merge seems to have broke `Observatory.vis_calc` because the axes ordering of `fringe_cube` and `beam_cube` were flipped. This PR fixes this, and also increases test coverage that would have caught that break.

Additionally, adds a version.history_string function for propagating version info to simulator outputs