### PR TITLE
propagates beam_pol to vis_calc

### DIFF
--- a/healvis/sky_model.py
+++ b/healvis/sky_model.py
@@ -68,7 +68,7 @@ class SkyModel(object):
 
     def set_data(self, data):
         """
-        Assign data to self. Must be an ndarray of shape (Nskies, Npix, Nfreqs).
+        Assign data to self. Must be an ndarray or mparray of shape (Nskies, Npix, Nfreqs).
 
         SkyModel currently only supports Stokes I sky models.
         """

--- a/healvis/sky_model.py
+++ b/healvis/sky_model.py
@@ -70,7 +70,7 @@ class SkyModel(object):
         """
         Assign data to self. Must be an ndarray or mparray of shape (Nskies, Npix, Nfreqs).
 
-        SkyModel currently only supports Stokes I sky models.
+        SkyModel currently only supports Stokes I sky models in Kelvin.
         """
         self.data = data
         self._update()

--- a/healvis/sky_model.py
+++ b/healvis/sky_model.py
@@ -26,7 +26,9 @@ f21 = 1.420405751e9
 
 
 class SkyModel(object):
-
+    """
+    SkyModel class
+    """
     Npix = None
     Nside = None
     Nskies = 1
@@ -41,6 +43,9 @@ class SkyModel(object):
     _updated = []
 
     def __init__(self, **kwargs):
+        """
+        Instantiate a SkyModel object.
+        """
         self.valid_params = ['Npix', 'Nside', 'Nskies', 'Nfreqs', 'indices', 'Z_array', 'ref_chan', 'pspec_amp', 'freq_array', 'data']
         self._updated = []
         for k, v in kwargs.items():
@@ -62,6 +67,11 @@ class SkyModel(object):
         return True
 
     def set_data(self, data):
+        """
+        Assign data to self. Must be an ndarray of shape (Nskies, Npix, Nfreqs).
+
+        SkyModel currently only supports Stokes I sky models.
+        """
         self.data = data
         self._update()
 


### PR DESCRIPTION
Now we can pass the `beam_pol` kwarg in `obs.make_visibilities` so that we can use `PowerBeam` objects with arbitrary polarization.