### PR TITLE
Light uvdata

### DIFF
--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -295,7 +295,6 @@ def setup_uvdata(array_layout=None, telescope_location=None, telescope_name=None
 
     if make_full:
         uv_obj = complete_uvdata(uv_obj, run_check=run_check)
-        setattr(uv_obj, 'incomplete', True)
 
     return uv_obj
 

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -415,7 +415,8 @@ def run_simulation(param_file, Nprocs=1, sjob_id=None, add_to_history=''):
     uvd_dict.update(param_dict['telescope'])
     uvd_dict.update(param_dict['freq'])
     uvd_dict.update(param_dict['time'])
-    uvd_dict.update(param_dict['beam'])
+    if 'pols' in param_dict['beam'].keys():
+        uvd_dict['pols'] = param_dict['beam']['pols']
     uvd_dict.update(param_dict['select'])
 
     if not 'make_full' in uvd_dict:

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -290,7 +290,6 @@ def setup_uvdata(array_layout=None, telescope_location=None, telescope_name=None
         bl_array.append(uvutils.antnums_to_baseline(a1, a2, 1))
     bl_array = np.asarray(bl_array)
 
-    
     uv_obj.time_array = time_array  # Keep length Nbls
     uv_obj.baseline_array = bl_array
 
@@ -419,7 +418,7 @@ def run_simulation(param_file, Nprocs=1, sjob_id=None, add_to_history=''):
         uvd_dict['pols'] = param_dict['beam']['pols']
     uvd_dict.update(param_dict['select'])
 
-    if not 'make_full' in uvd_dict:
+    if 'make_full' not in uvd_dict:
         uvd_dict['make_full'] = False
 
     uv_obj = setup_uvdata(**uvd_dict)

--- a/healvis/tests/test_simulator.py
+++ b/healvis/tests/test_simulator.py
@@ -18,7 +18,7 @@ def test_setup_uvdata():
     uvd = simulator.setup_uvdata(array_layout=os.path.join(DATA_PATH, "configs/HERA65_layout.csv"),
                                  telescope_location=(-30.72152777777791, 21.428305555555557, 1073.0000000093132),
                                  telescope_name="HERA", Nfreqs=10, start_freq=1e8, bandwidth=1e8, Ntimes=60,
-                                 time_cadence=100.0, start_time=2458101.0, pols=['xx'], no_autos=True, run_check=True)
+                                 time_cadence=100.0, start_time=2458101.0, pols=['xx'], no_autos=True, make_full=True, run_check=True)
     nt.assert_equal(uvd.Nbls, uvd.Nants_data * (uvd.Nants_data - 1) / 2)
 
     # check selection works
@@ -26,12 +26,12 @@ def test_setup_uvdata():
     uvd = simulator.setup_uvdata(array_layout=os.path.join(DATA_PATH, "configs/HERA65_layout.csv"),
                                  telescope_location=(-30.72152777777791, 21.428305555555557, 1073.0000000093132),
                                  telescope_name="HERA", Nfreqs=10, start_freq=1e8, bandwidth=1e8, Ntimes=60,
-                                 time_cadence=100.0, start_time=2458101.0, pols=['xx'], bls=bls, run_check=True)
+                                 time_cadence=100.0, start_time=2458101.0, pols=['xx'], bls=bls, make_full=True, run_check=True)
     nt.assert_equal(uvd.Nbls, len(bls))
     uvd = simulator.setup_uvdata(array_layout=os.path.join(DATA_PATH, "configs/HERA65_layout.csv"),
                                  telescope_location=(-30.72152777777791, 21.428305555555557, 1073.0000000093132),
                                  telescope_name="HERA", Nfreqs=10, start_freq=1e8, bandwidth=1e8, Ntimes=60,
-                                 time_cadence=100.0, start_time=2458101.0, pols=['xx'], bls=bls, antenna_nums=[11],
+                                 time_cadence=100.0, start_time=2458101.0, pols=['xx'], bls=bls, make_full=True, antenna_nums=[11],
                                  no_autos=False, run_check=True)
     nt.assert_equal(uvd.Nbls, 1)
 
@@ -83,7 +83,7 @@ def test_run_simulation_partial_freq():
     uvd = simulator.setup_uvdata(array_layout=os.path.join(DATA_PATH, "configs/HERA65_layout.csv"),
                                  telescope_location=(-30.72152777777791, 21.428305555555557, 1073.0000000093132),
                                  telescope_name="HERA", Ntimes=60, time_cadence=100.0, start_time=2458101.0,
-                                 pols=['xx'], bls=bls, run_check=True, freq_array=sky.freqs)
+                                 pols=['xx'], bls=bls, make_full=True, run_check=True, freq_array=sky.freqs)
     test_uvh5 = os.path.join(DATA_PATH, "test_freq_parallel_sim.uvh5")
     uvd.write_uvh5(test_uvh5, clobber=True)
 


### PR DESCRIPTION
[MERGE ONLY AFTER MERGING #15 ]

Allows setup to make an improper "light" uvdata object, without any arrays of length Nblts. The `baseline_array` and `time_array` are written as length `Nbls` and `Ntimes`, respectively. A separate function to "finish" the UVData is then called after the simulation is finished and (importantly) after the `SkyModel.data` attribute is cleared from memory.

This is to avoid the overhead of making several `Nblts` length arrays while other memory-intensive tasks are underway.

Unfortunately, the partial frequency simulation needs to have a valid UVData in place to continually write/read the existing file, so I don't think this mode can be used with the partial_freq function.