### PR TITLE
Various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source activate test-environment
   - conda install -c conda-forge healpy pycodestyle mpi4py
   - pip install coveralls
-  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git@partial_uvh5_history_append
+  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
   - pip install git+https://github.com/telegraphic/PyGSM.git
 script:
   - nosetests healvis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Bug fix in Observatory.beam_sq_int (missing square on Nside)
 - Restored support for redundancy selection.
 - Loading from hdf5 files into shared memory was not actually using the mparray.
 - Single-frequency simulations can be run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [1.0.0] - 2019-3-29
+## Unreleased
 
 ### Added
 
+- Frequency selections in obsparam to apply to loading skymodels
 - Documented convention that frequency array values refer to channel centers
 - Test for consistency among setup parameters.
 - Full support for all valid pyuvsim setup parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Chromatic gaussian beam with power law width scaling with frequency.
 - Frequency selections in obsparam to apply to loading skymodels
 - Documented convention that frequency array values refer to channel centers
 - Test for consistency among setup parameters.

--- a/healvis/beam_model.py
+++ b/healvis/beam_model.py
@@ -279,11 +279,17 @@ class AnalyticBeam(object):
         Currently this class only supports single-polarization beam models.
 
         Args:
-            beam_type : str or callable, type of beam to use. options=['uniform', 'gaussian', 'airy', callable]
-            gauss_width : float, standard deviation [degrees] for gaussian beam
-            spectral_index: (float, optional) Scale gaussian beam width as a power law with frequency.
-                                               With this, gauss_width indicates the width at the lowest frequency.
-            diameter : float, dish diameter [meter] used for airy beam
+            beam_type : str or callable
+                type of beam to use. options=['uniform', 'gaussian', 'airy', callable]
+            gauss_width : float
+                standard deviation [degrees] for gaussian beam
+                When spectral index is set, this represents the FWHM at the ref_freq
+            spectral_index : (float, optional)
+                Scale gaussian beam width as a power law with frequency.
+            ref_freq : (float, optional)
+                If set, this sets the reference frequency for the beam width power law.
+            diameter : float
+                dish diameter [meter] used for airy beam
 
         Notes:
             Uniform beam is a flat-top beam across the entire sky.

--- a/healvis/beam_model.py
+++ b/healvis/beam_model.py
@@ -306,7 +306,7 @@ class AnalyticBeam(object):
             if (not spectral_index == 0.0) and (ref_freq is None):
                 raise ValueError("ref_freq must be set for nonzero gaussian beam spectral index")
             elif ref_freq is None:
-                self.ref_freq = 1.0 # Flat spectrum anyway
+                self.ref_freq = 1.0  # Flat spectrum anyway
         elif beam_type == 'airy':
             if diameter is None:
                 raise KeyError("Dish diameter required for airy beam")
@@ -349,8 +349,8 @@ class AnalyticBeam(object):
             else:
                 beam_value = 1.0
         elif self.beam_type == 'gaussian':
-            sigmas = self.gauss_width * (freqs/self.ref_freq)**(self.spectral_index)
-            beam_value = np.exp(-(za[...,np.newaxis]**2) / (2 * sigmas**2))  # Peak normalized
+            sigmas = self.gauss_width * (freqs / self.ref_freq)**(self.spectral_index)
+            beam_value = np.exp(-(za[..., np.newaxis]**2) / (2 * sigmas**2))  # Peak normalized
         elif self.beam_type == 'airy':
             beam_value = airy_disk(za, freqs, diameter=self.diameter)
         elif callable(self.beam_type):

--- a/healvis/beam_model.py
+++ b/healvis/beam_model.py
@@ -232,8 +232,11 @@ class PowerBeam(UVBeam):
             az = np.array([az])
         if isinstance(za, (float, np.float, int, np.int)):
             za = np.array([za])
+        if isinstance(freqs, (float, np.float, int, np.int)):
+            freqs = np.array([freqs])
         az = np.asarray(az)
         za = np.asarray(za)
+        freqs = np.asarray(freqs)
 
         if self.pixel_coordinate_system == 'az_za':
             self.interpolation_function = 'az_za_simple'
@@ -320,6 +323,16 @@ class AnalyticBeam(object):
         Returns:
             beam_value : ndarray of beam power, with shape (Npix, Nfreqs) where Npix = len(za)
         """
+        if isinstance(az, (float, np.float, int, np.int)):
+            az = np.array([az])
+        if isinstance(za, (float, np.float, int, np.int)):
+            za = np.array([za])
+        if isinstance(freqs, (float, np.float, int, np.int)):
+            freqs = np.array([freqs])
+        az = np.asarray(az)
+        za = np.asarray(za)
+        freqs = np.asarray(freqs)
+
         if self.beam_type == 'uniform':
             if isinstance(az, np.ndarray):
                 if np.isscalar(freqs):

--- a/healvis/beam_model.py
+++ b/healvis/beam_model.py
@@ -318,12 +318,6 @@ class AnalyticBeam(object):
                 raise KeyError("Dish diameter required for airy beam")
             self.diameter = diameter
 
-    def plot_beam(self, az, za, freqs, **kwargs):
-        # TODO: needs development, and testing coverage?
-        fig = pl.figure()
-        pl.imshow(self.beam_val(az, za, freqs, **kwargs))
-        pl.show()
-
     def beam_val(self, az, za, freqs, **kwargs):
         """
         Evaluation of an analytic beam model.

--- a/healvis/observatory.py
+++ b/healvis/observatory.py
@@ -191,7 +191,7 @@ class Observatory(object):
         """
         za, az = self.calc_azza(Nside, pointing)
         beam_sq_int = np.sum(self.beam.beam_val(az, za, freqs, pol=beam_pol)**2, axis=0)
-        om = 4 * np.pi / (12.0 * Nside)
+        om = 4 * np.pi / (12.0 * Nside**2)
         beam_sq_int = beam_sq_int * om
 
         return beam_sq_int

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -662,7 +662,7 @@ def run_simulation(param_file, Nprocs=1, sjob_id=None, add_to_history=''):
 
     uv_obj = complete_uvdata(uv_obj)
 
-    uv_obj.extra_keywords = {'nside': sky.Nside, 'slurm_id': sjob_id}
+    uv_obj.extra_keywords = {'nside': sky.Nside, 'slurm_id': sjob_id, 'fov': obs.fov }
     uv_obj.extra_keywords.update(beam_sq_int)
     if beam_type == 'gaussian':
         fwhm = beam_attr['gauss_width'] * 2.355

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -762,7 +762,6 @@ def run_simulation_partial_freq(freq_chans, uvh5_file, skymod_file, fov=180, bea
     sky.read_hdf5(skymod_file, freq_chans=freq_chans, shared_memory=False)
 
     # Check that chosen freqs are a subset of the skymodel frequencies.
-
     assert np.isclose(sky.freqs, uvd.freq_array[0, freq_chans]).all(), "Frequency arrays in UHV5 file {} and SkyModel file {} don't agree".format(uvh5_file, skymod_file)
 
     # setup observatory

--- a/healvis/simulator.py
+++ b/healvis/simulator.py
@@ -662,7 +662,7 @@ def run_simulation(param_file, Nprocs=1, sjob_id=None, add_to_history=''):
 
     uv_obj = complete_uvdata(uv_obj)
 
-    uv_obj.extra_keywords = {'nside': sky.Nside, 'slurm_id': sjob_id, 'fov': obs.fov }
+    uv_obj.extra_keywords = {'nside': sky.Nside, 'slurm_id': sjob_id, 'fov': obs.fov}
     uv_obj.extra_keywords.update(beam_sq_int)
     if beam_type == 'gaussian':
         fwhm = beam_attr['gauss_width'] * 2.355

--- a/healvis/tests/test_beam_model.py
+++ b/healvis/tests/test_beam_model.py
@@ -65,6 +65,12 @@ def test_AnalyticBeam():
     nt.assert_equal(b.shape, (Npix, Nfreqs))  # assert array shape
     nt.assert_true(np.isclose(b[0, :], 1.0).all())  # assert peak normalized
 
+    # Chromatic Gaussian
+    A = beam_model.AnalyticBeam('gaussian', gauss_width=15.0, ref_freq=freqs[0], spectral_index=-1.0)
+    b = A.beam_val(az, za, freqs)
+    nt.assert_equal(b.shape, (Npix, Nfreqs))  # assert array shape
+    nt.assert_true(np.isclose(b[0, :], 1.0).all())  # assert peak normalized
+
     # Uniform
     A = beam_model.AnalyticBeam('uniform')
     b = A.beam_val(az, za, freqs)

--- a/healvis/tests/test_pspec.py
+++ b/healvis/tests/test_pspec.py
@@ -39,7 +39,7 @@ def test_pspec_amp():
     obs.set_pointings(obs.times_jd)
 
     obs.set_fov(fov)
-    obs.set_beam('uniform')
+    obs.set_beam('gaussian', gauss_width=7.37)
 
     skysig = 0.031
 
@@ -59,8 +59,7 @@ def test_pspec_amp():
     dspec_instr = np.abs(_vis)**2
 
     za, az = obs.calc_azza(sky.Nside, obs.pointing_centers[0])
-    beam_sq_int = np.sum(obs.beam.beam_val(az, za, freqs)**2, axis=0) * pix_area
-    beam_sq_int = beam_sq_int[0]    # Constant across frequencies
+    beam_sq_int = np.mean(obs.beam_sq_int(freqs, nside, obs.pointing_centers[0]))
 
     Bandwidth = freqs[-1] - freqs[0]
     scalar = cosmology.X2Y(sky.Z_array[sky.ref_chan]) * (Bandwidth / beam_sq_int)

--- a/healvis/tests/test_simulator.py
+++ b/healvis/tests/test_simulator.py
@@ -261,3 +261,16 @@ def test_redundant_setup():
 
     nt.assert_true(uvd0.Nbls == 66)
     nt.assert_true(uvd.Nbls == 65)
+
+
+def test_freq_time_params():
+    sky = sky_model.SkyModel()
+    sky.read_hdf5(os.path.join(DATA_PATH, 'gsm_nside32.hdf5'))
+    freqs = sky.freqs
+    times = np.linspace(2458570, 2458570 + 0.5, 239)
+    time_dict = utils.time_array_to_params(times)
+    freq_dict = utils.freq_array_to_params(freqs)
+    ftest = simulator.parse_frequency_params(freq_dict)
+    ttest = simulator.parse_time_params(time_dict)
+    nt.assert_true(np.allclose(ftest['freq_array'], freqs))
+    nt.assert_true(np.allclose(ttest['time_array'], times))

--- a/healvis/tests/test_sky_model.py
+++ b/healvis/tests/test_sky_model.py
@@ -90,3 +90,14 @@ def test_fewchannel_read():
     sky = sky_model.SkyModel()
     sky.read_hdf5(os.path.join(DATA_PATH, "gsm_nside32.hdf5"), freq_chans=chans, shared_memory=True)
     nt.assert_true(sky.freqs.size == 4)
+
+
+def test_freqselect_read():
+    # Using existing frequencies as selection on read
+    sky = sky_model.SkyModel()
+    sky.read_hdf5(os.path.join(DATA_PATH, "gsm_nside32.hdf5"))
+    subfreqs = sky.freqs[::2]
+    sky = sky_model.SkyModel()
+    sky.freqs = subfreqs
+    sky.read_hdf5(os.path.join(DATA_PATH, "gsm_nside32.hdf5"), do_not_overwrite_freqs=True)
+    nt.assert_true(sky.freqs.size == subfreqs.size)

--- a/healvis/utils.py
+++ b/healvis/utils.py
@@ -52,11 +52,11 @@ def time_array_to_params(time_array):
     if time_array.size < 2:
         raise ValueError("Time array must be longer than 1 to give meaningful results.")
 
-    fdict['time_cadence'] = np.diff(time_array)[0] * (24. * 3600.)
-    fdict['Ntimes'] = time_array.size
-    fdict['duration'] = fdict['time_cadence'] * fdict['Ntimes'] / (24. * 3600.)
-    fdict['start_time'] = time_array[0]
-    fdict['end_time'] = time_array[-1]
+    tdict['time_cadence'] = np.diff(time_array)[0] * (24. * 3600.)
+    tdict['Ntimes'] = time_array.size
+    tdict['duration'] = tdict['time_cadence'] * tdict['Ntimes'] / (24. * 3600.)
+    tdict['start_time'] = time_array[0]
+    tdict['end_time'] = time_array[-1]
 
     return tdict
 

--- a/scripts/make_gsm_shell.py
+++ b/scripts/make_gsm_shell.py
@@ -1,3 +1,4 @@
+#!/bin/env python
 # -*- mode: python; coding: utf-8 -*
 # Copyright (c) 2019 Radio Astronomy Software Group
 # Licensed under the 3-clause BSD License
@@ -16,9 +17,8 @@ try:
     import pygsm
 except ImportError:
     raise ImportError("pygsm package not found. This is required to use {}".format(os.path.basename(__file__)))
-import pyuvsim
 
-from healvis import sky_model
+from healvis import sky_model, simulator
 
 # -----------------------
 # Generate a SkyModel object
@@ -40,15 +40,14 @@ with open(param_file, 'r') as yfile:
 
 param_dict['config_path'] = '.'
 
-tele_dict, beam_list, beam_dict = pyuvsim.simsetup.parse_telescope_params(param_dict['telescope'], param_dict['config_path'])
-freq_dict = pyuvsim.simsetup.parse_frequency_params(param_dict['freq'])
+freq_dict = simulator.parse_frequency_params(param_dict['freq'])
 
 freq_array = freq_dict['freq_array'][0]
 
-sky = sky_model.SkyModel(freq_array=freq_array)
+sky = sky_model.SkyModel(freqs=freq_array)
 sky.Nside = args.nside
 
 data = sky_model.gsm_shell(sky.Nside, freq_array)
 sky.set_data(data)
 
-sky.write_hdf5('gsm_{:.2f}-{:.2f}MHz_nside{}.hdf5'.format(freq_array[0] / 1e6, freq_array[-1] / 1e6, args.nside))
+sky.write_hdf5('skymodels/gsm_{:.2f}-{:.2f}MHz_nside{}.hdf5'.format(freq_array[0] / 1e6, freq_array[-1] / 1e6, args.nside))

--- a/scripts/make_imaging_layout.py
+++ b/scripts/make_imaging_layout.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 
 layout_csv_name = 'imaging_layout.csv'
-Nants = 50
+Nants = 80
 freq = 100e6
 c = 3e8
 Nside = 128
@@ -15,9 +15,13 @@ Nside = 128
 res = np.sqrt(4 * np.pi / (12 * Nside**2))
 lam = c / freq
 maxbl = 1.22 * (lam / res)      # Resolution ~ 1.22 * lambda/maxbl.
+
+core_width = maxbl/2.
+sigma = core_width/2.355
+
 # Want to overresolve pixels (treating them as point sources)
 minbl = 5  # m
-E, N = np.random.uniform(minbl, maxbl, (2, Nants))
+E, N = np.random.normal(0, sigma, (2, Nants))
 U = np.zeros(Nants)
 
 enu = np.vstack((E, N, U)).T


### PR DESCRIPTION
Minor changes:
- There was a bug in `Observatory.beam_sq_int`. The pixel area calculation was dividing by Nside instead of Nside**2. It's fixed now, and the pspec tests will break if this isn't in place.
- Bug in setting up gaussian beams fixed.
- Restores the loop test on time/freq parsers.
- Gaussian-distributed antenna positions in the "imaging" array random antpos script.

Big changes:
- Enables support for gaussian beams with widths that vary as a power law with frequency.
- Skymodel file frequencies and simulator frequencies don't need to match perfectly -- If the simulator frequencies are a subset of the skymodel freqs, it will read in only those frequencies. Users don't have to make multiple skymodel files in order to simulate subbands with this change.